### PR TITLE
Max bytes per diskqueue (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,47 @@
 # go-diskqueue
 
-[![Build Status](https://github.com/nsqio/go-diskqueue/workflows/tests/badge.svg)](https://github.com/nsqio/go-diskqueue/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/nsqio/go-diskqueue.svg)](https://pkg.go.dev/github.com/nsqio/go-diskqueue) [![GitHub release](https://img.shields.io/github/release/nsqio/go-diskqueue.svg)](https://github.com/nsqio/go-diskqueue/releases/latest)
+This is a fork of https://github.com/nsqio/go-diskqueue with the additional support of total disk space limit.
+
+[![Build Status](https://travis-ci.com/kev1n80/go-diskqueue.svg?branch=master)](https://travis-ci.com/github/kev1n80/go-diskqueue) [![Go Reference](https://pkg.go.dev/badge/github.com/kev1n80/go-diskqueue.svg)](https://pkg.go.dev/github.com/kev1n80/go-diskqueue) [![GitHub release](https://img.shields.io/github/release/kev1n80/go-diskqueue.svg)](https://github.com/kev1n80/go-diskqueue/releases/latest)
 
 A Go package providing a filesystem-backed FIFO queue
 
 Pulled out of https://github.com/nsqio/nsq
+
+# Description
+Diskqueue is a synchronized "filesystem-backed FIFO queue” meaning it will store data you pass in by writing them to file.
+
+Diskqueue writes messages and their message length to files in the order: message length in binary and then message. This allows Diskqueue to know how much of the file to read in order to get the next message. Once Diskqueue reads a file completely (when the number of bytes read surpasses the size of the file), it deletes the file. 
+
+In terms of threads, creating a Diskqueue object starts a “worker thread” by calling the private function ioLoop, which is a continuous loop that accepts requests to read, write, empty, get depth, or exit. This worker thread DOES NOT create other worker threads to handle tasks asynchronously. It is important to note that Diskqueue will sync if needed (i.e. set by sync flag after user retrieves read data) before handling a new request. Using a public function can be seen as creating a request to the Diskqueue object’s “worker thread” which is implemented by using Channels. 
+
+# Disk Space limit Feature
+The original DiskQueue package did not contain a disk size limit feature; however, this forked repo does! By using a separate constructor `NewWithDiskSpace`, the user can use this disk space limit feature which will delete the oldest files in order to create space for new, incoming data.
+
+In order to accurately adjust `depth` when a file is deleted, DiskQueue will store the number of messages in a file by writing this number to the end of the file. That way we can access this number and decrement `depth` accordingly.
+
+Note: The disk size limit must be greater than 56 bytes which is reserved for the meta data file.
+
+# Public Functions
+
+## Put([]byte) error
+Add data to the queue, and if a failure occurs none of the data will be written.
+
+## ReadChan() <-chan []byte
+This is expected to be an *unbuffered* channel that will not close until `Close()` or `Delete()` is called.
+
+## Close() error
+Cleans up the queue and persists the current state to metadata. 
+
+## Delete() error
+Cleans up the queue, but does not save the current state to metadata.
+
+## Depth() int64
+Returns the number of data in the queue; however, this number can become inaccurate if a file becomes corrupted or unaccessible.
+Although there are times when this number can be inaccurate, this number will always be 0 when there is nothing in the queue due to the `checkTailCorruption(depth int64)` private function.
+
+## Empty() error
+Empties out the queue by deleting all of the files containing data.
+
+## TotalBytesFolderSize() int64
+Returns the total number of bytes the content in the targeted folder take up.

--- a/diskqueue.go
+++ b/diskqueue.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
+	"regexp"
 	"sync"
 	"time"
 )
@@ -19,11 +21,13 @@ import (
 type LogLevel int
 
 const (
-	DEBUG = LogLevel(1)
-	INFO  = LogLevel(2)
-	WARN  = LogLevel(3)
-	ERROR = LogLevel(4)
-	FATAL = LogLevel(5)
+	DEBUG               = LogLevel(1)
+	INFO                = LogLevel(2)
+	WARN                = LogLevel(3)
+	ERROR               = LogLevel(4)
+	FATAL               = LogLevel(5)
+	numFileMsgBytes     = 8
+	maxMetaDataFileSize = 56
 )
 
 type AppLogFunc func(lvl LogLevel, f string, args ...interface{})
@@ -52,6 +56,7 @@ type Interface interface {
 	Delete() error
 	Depth() int64
 	Empty() error
+	TotalBytesFolderSize() int64
 }
 
 // diskQueue implements a filesystem backed FIFO queue
@@ -59,17 +64,21 @@ type diskQueue struct {
 	// 64bit atomic vars need to be first for proper alignment on 32bit platforms
 
 	// run-time state (also persisted to disk)
-	readPos      int64
-	writePos     int64
-	readFileNum  int64
-	writeFileNum int64
-	depth        int64
+	readPos            int64
+	writePos           int64
+	readFileNum        int64
+	writeFileNum       int64
+	readMessages       int64 // Number of read messages. It's used to update depth.
+	writeMessages      int64 // Number of write messages. It's used to update depth.
+	totalDiskSpaceUsed int64
+	depth              int64
 
 	sync.RWMutex
 
 	// instantiation time metadata
 	name                string
 	dataPath            string
+	maxBytesDiskSpace   int64
 	maxBytesPerFile     int64 // cannot change once created
 	maxBytesPerFileRead int64
 	minMsgSize          int32
@@ -105,6 +114,11 @@ type diskQueue struct {
 	exitSyncChan      chan int
 
 	logf AppLogFunc
+
+	// disk limit implementation flag
+	enableDiskLimitation bool
+
+	badFileNameRegexp, fileNameRegexp *regexp.Regexp
 }
 
 // New instantiates an instance of diskQueue, retrieving metadata
@@ -112,24 +126,63 @@ type diskQueue struct {
 func New(name string, dataPath string, maxBytesPerFile int64,
 	minMsgSize int32, maxMsgSize int32,
 	syncEvery int64, syncTimeout time.Duration, logf AppLogFunc) Interface {
+
+	return NewWithDiskSpace(name, dataPath,
+		0, maxBytesPerFile,
+		minMsgSize, maxMsgSize,
+		syncEvery, syncTimeout, logf)
+}
+
+// Another constructor that allows users to use Disk Space Limit feature
+// If user is not using Disk Space Limit feature, maxBytesDiskSpace will
+// be 0
+func NewWithDiskSpace(name string, dataPath string,
+	maxBytesDiskSpace int64, maxBytesPerFile int64,
+	minMsgSize int32, maxMsgSize int32,
+	syncEvery int64, syncTimeout time.Duration, logf AppLogFunc) Interface {
+	enableDiskLimitation := true
+	if maxBytesDiskSpace <= 0 {
+		enableDiskLimitation = false
+	}
 	d := diskQueue{
-		name:              name,
-		dataPath:          dataPath,
-		maxBytesPerFile:   maxBytesPerFile,
-		minMsgSize:        minMsgSize,
-		maxMsgSize:        maxMsgSize,
-		readChan:          make(chan []byte),
-		peekChan:          make(chan []byte),
-		depthChan:         make(chan int64),
-		writeChan:         make(chan []byte),
-		writeResponseChan: make(chan error),
-		emptyChan:         make(chan int),
-		emptyResponseChan: make(chan error),
-		exitChan:          make(chan int),
-		exitSyncChan:      make(chan int),
-		syncEvery:         syncEvery,
-		syncTimeout:       syncTimeout,
-		logf:              logf,
+		name:                 name,
+		dataPath:             dataPath,
+		maxBytesDiskSpace:    maxBytesDiskSpace,
+		maxBytesPerFile:      maxBytesPerFile,
+		minMsgSize:           minMsgSize,
+		maxMsgSize:           maxMsgSize,
+		readChan:             make(chan []byte),
+		peekChan:             make(chan []byte),
+		depthChan:            make(chan int64),
+		writeChan:            make(chan []byte),
+		writeResponseChan:    make(chan error),
+		emptyChan:            make(chan int),
+		emptyResponseChan:    make(chan error),
+		exitChan:             make(chan int),
+		exitSyncChan:         make(chan int),
+		syncEvery:            syncEvery,
+		syncTimeout:          syncTimeout,
+		logf:                 logf,
+		enableDiskLimitation: enableDiskLimitation,
+	}
+
+	err := d.start()
+	if err != nil {
+		return nil
+	}
+
+	return &d
+}
+
+// Get the last known state of DiskQueue from metadata and start ioLoop
+func (d *diskQueue) start() error {
+	// ensure that DiskQueue has enough space to write the metadata file + at least one data file with max size + message size
+	if d.enableDiskLimitation && (d.maxBytesDiskSpace <= maxMetaDataFileSize+d.maxBytesPerFile) {
+		errorMsg := fmt.Sprintf(
+			"disk size limit too small(%d): not enough space for MetaData file (size=%d) and at least one data file with max size (maxBytesPerFile=%d).",
+			d.maxBytesDiskSpace, maxMetaDataFileSize, d.maxBytesPerFile)
+		d.logf(ERROR, "DISKQUEUE(%s) - %s", errorMsg)
+		return errors.New(errorMsg)
 	}
 
 	// no need to lock here, nothing else could possibly be touching this instance
@@ -138,8 +191,14 @@ func New(name string, dataPath string, maxBytesPerFile int64,
 		d.logf(ERROR, "DISKQUEUE(%s) failed to retrieveMetaData - %s", d.name, err)
 	}
 
+	d.fileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d+.dat$`)
+	d.badFileNameRegexp = regexp.MustCompile(`^` + d.name + `.diskqueue.\d+.dat.bad$`)
+
+	d.updateTotalDiskSpaceUsed()
+
 	go d.ioLoop()
-	return &d
+
+	return nil
 }
 
 // Depth returns the depth of the queue
@@ -150,6 +209,20 @@ func (d *diskQueue) Depth() int64 {
 		depth = d.depth
 	}
 	return depth
+}
+
+// Returns to total size of the contents (files) in the directory located in the dataPath
+func (d *diskQueue) TotalBytesFolderSize() int64 {
+	var totalFolderSizeBytes int64
+
+	getTotalFolderSizeBytes := func(fileInfo os.FileInfo) error {
+		totalFolderSizeBytes += fileInfo.Size()
+		return nil
+	}
+
+	d.walkDiskQueueDir(getTotalFolderSizeBytes)
+
+	return totalFolderSizeBytes
 }
 
 // ReadChan returns the receive-only []byte channel for reading data
@@ -276,6 +349,12 @@ func (d *diskQueue) skipToNextRWFile() error {
 	d.nextReadPos = 0
 	d.depth = 0
 
+	if d.enableDiskLimitation {
+		d.totalDiskSpaceUsed = 0
+		d.readMessages = 0
+		d.writeMessages = 0
+	}
+
 	return err
 }
 
@@ -310,6 +389,10 @@ func (d *diskQueue) readOne() ([]byte, error) {
 			stat, err := d.readFile.Stat()
 			if err == nil {
 				d.maxBytesPerFileRead = stat.Size()
+				if d.enableDiskLimitation {
+					// last 8 bytes are reserved for the number of messages in this file
+					d.maxBytesPerFileRead -= numFileMsgBytes
+				}
 			}
 		}
 
@@ -362,38 +445,202 @@ func (d *diskQueue) readOne() ([]byte, error) {
 	return readBuf, nil
 }
 
+func (d *diskQueue) removeBadFile(oldestBadFileInfo os.FileInfo) error {
+	var err error
+	badFileFilePath := path.Join(d.dataPath, oldestBadFileInfo.Name())
+
+	// remove file if it exists
+	err = os.Remove(badFileFilePath)
+	if err != nil {
+		d.logf(ERROR, "DISKQUEUE(%s) failed to remove .bad file(%s) - %s", d.name, oldestBadFileInfo.Name(), err)
+		d.updateTotalDiskSpaceUsed()
+		return err
+	} else {
+		// recaclulate total bad files disk size to get most accurate info
+		d.totalDiskSpaceUsed -= oldestBadFileInfo.Size()
+		d.logf(INFO, "DISKQUEUE(%s) removed .bad file(%s) of size(%d bytes) to free up disk space", d.name, oldestBadFileInfo.Name(), oldestBadFileInfo.Size())
+	}
+
+	return nil
+}
+
+func (d *diskQueue) readNumOfMessages(fileName string) (int64, error) {
+	var err error
+
+	if d.readFile == nil {
+		d.readFile, err = os.OpenFile(fileName, os.O_RDONLY, 0600)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	closeReadFile := func() {
+		d.readFile.Close()
+		d.readFile = nil
+	}
+	defer closeReadFile()
+
+	// read total messages number at the end of the file
+	_, err = d.readFile.Seek(-numFileMsgBytes, 2)
+	if err != nil {
+		return 0, err
+	}
+
+	var totalMessages int64
+	err = binary.Read(d.readFile, binary.BigEndian, &totalMessages)
+	if err != nil {
+		return 0, err
+	}
+
+	return totalMessages, nil
+}
+
+func (d *diskQueue) removeReadFile() error {
+	if d.readFileNum == d.writeFileNum {
+		d.skipToNextRWFile()
+		return nil
+	}
+
+	curFileName := d.fileName(d.readFileNum)
+	totalMessages, err := d.readNumOfMessages(curFileName)
+	if err != nil {
+		return err
+	}
+
+	// update depth with the remaining number of messages
+	d.depth -= totalMessages - d.readMessages
+
+	// we have not finished reading this file
+	if d.readFileNum == d.nextReadFileNum {
+		d.nextReadFileNum++
+		d.nextReadPos = 0
+	}
+
+	d.moveToNextReadFile()
+
+	return nil
+}
+
+// walk through all of the files in the DiskQueue directory
+func (d *diskQueue) walkDiskQueueDir(fn func(os.FileInfo) error) error {
+	fileInfos, err := ioutil.ReadDir(d.dataPath)
+
+	if err != nil {
+		return err
+	}
+
+	for _, fileInfo := range fileInfos {
+		// only go through files and skip directories
+		if !fileInfo.IsDir() {
+			err = fn(fileInfo)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *diskQueue) getAllBadFileInfo() ([]os.FileInfo, error) {
+	var badFileInfos []os.FileInfo
+
+	getAllBadFileInfo := func(fileInfo os.FileInfo) error {
+		// only accept "bad" files created by this DiskQueue object
+		if d.badFileNameRegexp.MatchString(fileInfo.Name()) {
+			badFileInfos = append(badFileInfos, fileInfo)
+		}
+
+		return nil
+	}
+
+	err := d.walkDiskQueueDir(getAllBadFileInfo)
+
+	return badFileInfos, err
+}
+
+// get the accurate total non-"bad" file size
+func (d *diskQueue) updateTotalDiskSpaceUsed() {
+	d.totalDiskSpaceUsed = maxMetaDataFileSize
+
+	updateTotalDiskSpaceUsed := func(fileInfo os.FileInfo) error {
+		// only accept files created by this DiskQueue object
+		if d.fileNameRegexp.MatchString(fileInfo.Name()) || d.badFileNameRegexp.MatchString(fileInfo.Name()) {
+			d.totalDiskSpaceUsed += fileInfo.Size()
+		}
+
+		return nil
+	}
+
+	err := d.walkDiskQueueDir(updateTotalDiskSpaceUsed)
+	if err != nil {
+		d.logf(ERROR, "DISKQUEUE(%s) failed to update write bytes - %s", d.name, err)
+	}
+}
+
+func (d *diskQueue) freeDiskSpace(expectedBytesIncrease int64) error {
+	var err error
+	var badFileInfos []os.FileInfo
+
+	badFileInfos, err = d.getAllBadFileInfo()
+	if err != nil {
+		d.logf(ERROR, "DISKQUEUE(%s) failed to retrieve all .bad file info - %s", d.name, err)
+	}
+
+	// keep freeing up disk space until we have enough space to write this message
+	for _, badFileInfo := range badFileInfos {
+		if d.totalDiskSpaceUsed+expectedBytesIncrease <= d.maxBytesDiskSpace {
+			return nil
+		}
+		d.removeBadFile(badFileInfo)
+	}
+	for d.readFileNum <= d.writeFileNum {
+		if d.totalDiskSpaceUsed+expectedBytesIncrease <= d.maxBytesDiskSpace {
+			return nil
+		}
+		// delete the read file (make space)
+		readFileToDeleteNum := d.readFileNum
+		err = d.removeReadFile()
+		if err != nil {
+			d.logf(ERROR, "DISKQUEUE(%s) failed to remove file(%s) - %s", d.name, d.fileName(readFileToDeleteNum), err)
+			d.handleReadError()
+			return err
+		} else {
+			d.logf(INFO, "DISKQUEUE(%s) removed file(%s) to free up disk space", d.name, d.fileName(readFileToDeleteNum))
+		}
+		d.updateTotalDiskSpaceUsed()
+	}
+
+	if d.totalDiskSpaceUsed+expectedBytesIncrease > d.maxBytesDiskSpace {
+		return fmt.Errorf("could not make space for totalDiskSpaceUsed = %d, expectedBytesIncrease = %d, with maxBytesDiskSpace = %d ", d.totalDiskSpaceUsed, expectedBytesIncrease, d.maxBytesDiskSpace)
+	}
+
+	return nil
+}
+
+// check if there is enough available disk space to write new data to file
+func (d *diskQueue) checkDiskSpace(expectedBytesIncrease int64) error {
+	// If the data to be written is bigger than the disk size limit, do not write
+	if expectedBytesIncrease > d.maxBytesDiskSpace {
+		errorMsg := fmt.Sprintf(
+			"message size(%d) surpasses disk size limit(%d)",
+			expectedBytesIncrease, d.maxBytesDiskSpace)
+		d.logf(ERROR, "DISKQUEUE(%s) - %s", d.name, errorMsg)
+		return errors.New(errorMsg)
+	}
+
+	// check if we have enough space to write this message
+	if d.totalDiskSpaceUsed+expectedBytesIncrease > d.maxBytesDiskSpace {
+		return d.freeDiskSpace(expectedBytesIncrease)
+	}
+	return nil
+}
+
 // writeOne performs a low level filesystem write for a single []byte
 // while advancing write positions and rolling files, if necessary
 func (d *diskQueue) writeOne(data []byte) error {
 	var err error
 
-	dataLen := int32(len(data))
-	totalBytes := int64(4 + dataLen)
-
-	if dataLen < d.minMsgSize || dataLen > d.maxMsgSize {
-		return fmt.Errorf("invalid message write size (%d) minMsgSize=%d maxMsgSize=%d", dataLen, d.minMsgSize, d.maxMsgSize)
-	}
-
-	// will not wrap-around if maxBytesPerFile + maxMsgSize < Int64Max
-	if d.writePos > 0 && d.writePos+totalBytes > d.maxBytesPerFile {
-		if d.readFileNum == d.writeFileNum {
-			d.maxBytesPerFileRead = d.writePos
-		}
-
-		d.writeFileNum++
-		d.writePos = 0
-
-		// sync every time we start writing to a new file
-		err = d.sync()
-		if err != nil {
-			d.logf(ERROR, "DISKQUEUE(%s) failed to sync - %s", d.name, err)
-		}
-
-		if d.writeFile != nil {
-			d.writeFile.Close()
-			d.writeFile = nil
-		}
-	}
 	if d.writeFile == nil {
 		curFileName := d.fileName(d.writeFileNum)
 		d.writeFile, err = os.OpenFile(curFileName, os.O_RDWR|os.O_CREATE, 0600)
@@ -413,6 +660,34 @@ func (d *diskQueue) writeOne(data []byte) error {
 		}
 	}
 
+	dataLen := int32(len(data))
+
+	if dataLen < d.minMsgSize || dataLen > d.maxMsgSize {
+		return fmt.Errorf("invalid message write size (%d) minMsgSize=%d maxMsgSize=%d", dataLen, d.minMsgSize, d.maxMsgSize)
+	}
+
+	totalBytes := int64(4 + dataLen)
+	reachedFileSizeLimit := false
+
+	if d.enableDiskLimitation {
+		expectedBytesIncrease := totalBytes
+		// check if we will reach or surpass file size limit
+		if d.writePos+totalBytes+numFileMsgBytes >= d.maxBytesPerFile {
+			reachedFileSizeLimit = true
+			expectedBytesIncrease += numFileMsgBytes
+		}
+
+		// free disk space if needed
+		err = d.checkDiskSpace(expectedBytesIncrease)
+		if err != nil {
+			return err
+		}
+	} else if d.writePos+totalBytes >= d.maxBytesPerFile {
+		reachedFileSizeLimit = true
+	}
+
+	// add all data to writeBuf before writing to file
+	// this causes everything to be written to file or nothing
 	d.writeBuf.Reset()
 	err = binary.Write(&d.writeBuf, binary.BigEndian, dataLen)
 	if err != nil {
@@ -422,6 +697,15 @@ func (d *diskQueue) writeOne(data []byte) error {
 	_, err = d.writeBuf.Write(data)
 	if err != nil {
 		return err
+	}
+
+	// check if we reached the file size limit with this message
+	if d.enableDiskLimitation && reachedFileSizeLimit {
+		// write number of messages in binary to file
+		err = binary.Write(&d.writeBuf, binary.BigEndian, d.writeMessages+1)
+		if err != nil {
+			return err
+		}
 	}
 
 	// only write to the file once
@@ -435,6 +719,35 @@ func (d *diskQueue) writeOne(data []byte) error {
 	d.writePos += totalBytes
 	d.depth += 1
 
+	if d.enableDiskLimitation {
+		d.totalDiskSpaceUsed += totalBytes
+		d.writeMessages += 1
+	}
+
+	if reachedFileSizeLimit {
+		if d.readFileNum == d.writeFileNum {
+			d.maxBytesPerFileRead = d.writePos
+		}
+
+		d.writeFileNum++
+		d.writePos = 0
+
+		if d.enableDiskLimitation {
+			d.writeMessages = 0
+		}
+
+		// sync every time we start writing to a new file
+		err = d.sync()
+		if err != nil {
+			d.logf(ERROR, "DISKQUEUE(%s) failed to sync - %s", d.name, err)
+		}
+
+		if d.writeFile != nil {
+			d.writeFile.Close()
+			d.writeFile = nil
+		}
+	}
+
 	return err
 }
 
@@ -447,6 +760,10 @@ func (d *diskQueue) sync() error {
 			d.writeFile = nil
 			return err
 		}
+	}
+
+	if d.enableDiskLimitation {
+		d.updateTotalDiskSpaceUsed()
 	}
 
 	err := d.persistMetaData()
@@ -471,13 +788,23 @@ func (d *diskQueue) retrieveMetaData() error {
 	defer f.Close()
 
 	var depth int64
-	_, err = fmt.Fscanf(f, "%d\n%d,%d\n%d,%d\n",
-		&depth,
-		&d.readFileNum, &d.readPos,
-		&d.writeFileNum, &d.writePos)
+	// if user is using disk space limit feature
+	if d.enableDiskLimitation {
+		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
+			&depth,
+			&d.readFileNum, &d.readMessages, &d.readPos,
+			&d.writeFileNum, &d.writeMessages, &d.writePos)
+	} else {
+		_, err = fmt.Fscanf(f, "%d\n%d,%d\n%d,%d\n",
+			&depth,
+			&d.readFileNum, &d.readPos,
+			&d.writeFileNum, &d.writePos)
+	}
+
 	if err != nil {
 		return err
 	}
+
 	d.depth = depth
 	d.nextReadFileNum = d.readFileNum
 	d.nextReadPos = d.readPos
@@ -522,10 +849,18 @@ func (d *diskQueue) persistMetaData() error {
 		return err
 	}
 
-	_, err = fmt.Fprintf(f, "%d\n%d,%d\n%d,%d\n",
-		d.depth,
-		d.readFileNum, d.readPos,
-		d.writeFileNum, d.writePos)
+	// if user is using disk space limit feature
+	if d.enableDiskLimitation {
+		_, err = fmt.Fprintf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
+			d.depth,
+			d.readFileNum, d.readMessages, d.readPos,
+			d.writeFileNum, d.writeMessages, d.writePos)
+	} else {
+		_, err = fmt.Fprintf(f, "%d\n%d,%d\n%d,%d\n",
+			d.depth,
+			d.readFileNum, d.readPos,
+			d.writeFileNum, d.writePos)
+	}
 	if err != nil {
 		f.Close()
 		return err
@@ -585,23 +920,44 @@ func (d *diskQueue) checkTailCorruption(depth int64) {
 	}
 }
 
-func (d *diskQueue) moveForward() {
+func (d *diskQueue) moveToNextReadFile() {
 	oldReadFileNum := d.readFileNum
 	d.readFileNum = d.nextReadFileNum
 	d.readPos = d.nextReadPos
-	d.depth -= 1
 
 	// see if we need to clean up the old file
 	if oldReadFileNum != d.nextReadFileNum {
+
 		// sync every time we start reading from a new file
 		d.needSync = true
 
 		fn := d.fileName(oldReadFileNum)
+		oldFileInfo, _ := os.Stat(fn)
+
 		err := os.Remove(fn)
 		if err != nil {
 			d.logf(ERROR, "DISKQUEUE(%s) failed to Remove(%s) - %s", d.name, fn, err)
+		} else {
+			d.logf(INFO, "DISKQUEUE(%s) removed(%s) of size(%d bytes)", d.name, fn, oldFileInfo.Size())
+		}
+
+		if d.enableDiskLimitation {
+			d.readMessages = 0
+			if err != nil {
+				d.logf(ERROR, "DISKQUEUE(%s) failed to update write bytes - %s", d.name, err)
+			}
 		}
 	}
+}
+
+func (d *diskQueue) moveForward() {
+	d.depth -= 1
+
+	if d.enableDiskLimitation {
+		d.readMessages += 1
+	}
+
+	d.moveToNextReadFile()
 
 	d.checkTailCorruption(d.depth)
 }
@@ -617,6 +973,10 @@ func (d *diskQueue) handleReadError() {
 		}
 		d.writeFileNum++
 		d.writePos = 0
+
+		if d.enableDiskLimitation {
+			d.writeMessages = 0
+		}
 	}
 
 	badFn := d.fileName(d.readFileNum)
@@ -637,6 +997,9 @@ func (d *diskQueue) handleReadError() {
 	d.readPos = 0
 	d.nextReadFileNum = d.readFileNum
 	d.nextReadPos = 0
+	if d.enableDiskLimitation {
+		d.readMessages = 0
+	}
 
 	// significant state change, schedule a sync on the next iteration
 	d.needSync = true

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strconv"
 	"sync"
@@ -148,6 +149,7 @@ func TestDiskQueuePeek(t *testing.T) {
 	t.Run("roll", func(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			err := dq.Put(msg)
+
 			Nil(t, err)
 			Equal(t, int64(i+1), dq.Depth())
 		}
@@ -293,11 +295,7 @@ func TestDiskQueueCorruption(t *testing.T) {
 	dq := New(dqName, tmpDir, 1000, 10, 1<<10, 5, 2*time.Second, l)
 	defer dq.Close()
 
-	msg := make([]byte, 120) // 124 bytes per message, 8 messages (992 bytes) per file
-	msg[0] = 91
-	msg[62] = 4
-	msg[119] = 211
-
+	msg := make([]byte, 123) // 127 bytes per message, 8 (1016 bytes) messages per file
 	for i := 0; i < 25; i++ {
 		dq.Put(msg)
 	}
@@ -306,7 +304,7 @@ func TestDiskQueueCorruption(t *testing.T) {
 
 	// corrupt the 2nd file
 	dqFn := dq.(*diskQueue).fileName(1)
-	os.Truncate(dqFn, 400) // 3 valid messages, 5 corrupted
+	os.Truncate(dqFn, 500) // 3 valid messages, 5 corrupted
 
 	for i := 0; i < 19; i++ { // 1 message leftover in 4th file
 		Equal(t, msg, <-dq.ReadChan())
@@ -328,34 +326,19 @@ func TestDiskQueueCorruption(t *testing.T) {
 	dq.Put(msg)
 
 	Equal(t, msg, <-dq.ReadChan())
-
-	dq.Put(msg)
-	dq.Put(msg)
-	// corrupt the last file
-	dqFn = dq.(*diskQueue).fileName(5)
-	os.Truncate(dqFn, 100)
-
-	Equal(t, int64(2), dq.Depth())
-
-	// return one message and try reading again from corrupted file
-	<-dq.ReadChan()
-
-	// give diskqueue time to handle read error
-	time.Sleep(50 * time.Millisecond)
-
-	// the last log file is now considered corrupted leaving no more log messages
-	Equal(t, int64(0), dq.Depth())
 }
 
 type md struct {
-	depth        int64
-	readFileNum  int64
-	writeFileNum int64
-	readPos      int64
-	writePos     int64
+	depth         int64
+	readFileNum   int64
+	writeFileNum  int64
+	readMessages  int64
+	writeMessages int64
+	readPos       int64
+	writePos      int64
 }
 
-func readMetaDataFile(fileName string, retried int) md {
+func readMetaDataFile(fileName string, retried int, enableDiskLimitation bool) md {
 	f, err := os.OpenFile(fileName, os.O_RDONLY, 0600)
 	if err != nil {
 		// provide a simple retry that results in up to
@@ -363,17 +346,25 @@ func readMetaDataFile(fileName string, retried int) md {
 		if retried < 9 {
 			retried++
 			time.Sleep(50 * time.Millisecond)
-			return readMetaDataFile(fileName, retried)
+			return readMetaDataFile(fileName, retried, enableDiskLimitation)
 		}
 		panic(err)
 	}
 	defer f.Close()
 
 	var ret md
-	_, err = fmt.Fscanf(f, "%d\n%d,%d\n%d,%d\n",
-		&ret.depth,
-		&ret.readFileNum, &ret.readPos,
-		&ret.writeFileNum, &ret.writePos)
+
+	if enableDiskLimitation {
+		_, err = fmt.Fscanf(f, "%d\n%d,%d,%d\n%d,%d,%d\n",
+			&ret.depth,
+			&ret.readFileNum, &ret.readMessages, &ret.readPos,
+			&ret.writeFileNum, &ret.writeMessages, &ret.writePos)
+	} else {
+		_, err = fmt.Fscanf(f, "%d\n%d,%d\n%d,%d\n",
+			&ret.depth,
+			&ret.readFileNum, &ret.readPos,
+			&ret.writeFileNum, &ret.writePos)
+	}
 	if err != nil {
 		panic(err)
 	}
@@ -395,7 +386,7 @@ func TestDiskQueueSyncAfterRead(t *testing.T) {
 	dq.Put(msg)
 
 	for i := 0; i < 10; i++ {
-		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0)
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, false)
 		if d.depth == 1 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
@@ -413,12 +404,574 @@ next:
 	<-dq.ReadChan()
 
 	for i := 0; i < 10; i++ {
-		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0)
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, false)
 		if d.depth == 1 &&
 			d.readFileNum == 0 &&
 			d.writeFileNum == 0 &&
 			d.readPos == 1004 &&
 			d.writePos == 2008 {
+			// success
+			goto done
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+done:
+}
+
+func TestDiskQueueSyncAfterReadWithDiskSizeImplementation(t *testing.T) {
+	l := NewTestLogger(t)
+	dqName := "test_disk_queue_read_with_disk_size_implementation" + strconv.Itoa(int(time.Now().Unix()))
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	dq := NewWithDiskSpace(dqName, tmpDir, 6040, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
+	defer dq.Close()
+
+	msgSize := 1000
+	msg := make([]byte, msgSize)
+	dq.Put(msg)
+
+	if dq.Depth() != 1 {
+		panic("fail")
+	}
+
+	var d md
+	for i := 0; i < 20; i++ {
+		d = readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 1 &&
+			d.readFileNum == 0 &&
+			d.writeFileNum == 0 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 1 &&
+			d.readPos == 0 &&
+			d.writePos == 1004 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 1004+maxMetaDataFileSize {
+			// success
+			goto next
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+next:
+	dq.Put(msg)
+	<-dq.ReadChan()
+
+	if dq.Depth() != 1 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 1 &&
+			d.readFileNum == 0 &&
+			d.writeFileNum == 0 &&
+			d.readMessages == 1 &&
+			d.writeMessages == 2 &&
+			d.readPos == 1004 &&
+			d.writePos == 2008 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 2008+maxMetaDataFileSize {
+			// success
+			goto completeWriteFile
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+completeWriteFile:
+	// meet the file size limit exactly (2048 bytes) when writeFileNum
+	// equals readFileNum
+	totalBytes := 2 * (msgSize + 4)
+	bytesRemaining := 2048 - (totalBytes + 8)
+	oneByteMsgSizeIncrease := 5
+	dq.Put(make([]byte, bytesRemaining-4-oneByteMsgSizeIncrease))
+	dq.Put(make([]byte, 1))
+
+	if dq.Depth() != 3 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		// test that write position and messages reset when a new file is created
+		// test the writeFileNum correctly increments
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 3 &&
+			d.readFileNum == 0 &&
+			d.writeFileNum == 1 &&
+			d.readMessages == 1 &&
+			d.writeMessages == 0 &&
+			d.readPos == 1004 &&
+			d.writePos == 0 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 2048+maxMetaDataFileSize {
+			// success
+			goto completeReadFile
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+completeReadFile:
+	dq.Put(msg)
+
+	<-dq.ReadChan()
+	<-dq.ReadChan()
+	<-dq.ReadChan()
+
+	if dq.Depth() != 1 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		// test that read position and messages reset when a file is completely read
+		// test the readFileNum correctly increments
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 1 &&
+			d.readFileNum == 1 &&
+			d.writeFileNum == 1 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 1 &&
+			d.readPos == 0 &&
+			d.writePos == 1004 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 1004+maxMetaDataFileSize {
+			// success
+			goto completeWriteFileAgain
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+completeWriteFileAgain:
+	// make writeFileNum ahead of readFileNum
+	dq.Put(msg)
+	dq.Put(msg)
+
+	// meet the file size limit exactly (2048 bytes) when writeFileNum
+	// is ahead of readFileNum
+	dq.Put(msg)
+	dq.Put(msg)
+	dq.Put(make([]byte, bytesRemaining-4-oneByteMsgSizeIncrease))
+	dq.Put(make([]byte, 1))
+
+	if dq.Depth() != 7 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		// test that write position and messages reset when a file is completely read
+		// test the writeFileNum correctly increments
+		d = readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 7 &&
+			d.readFileNum == 1 &&
+			d.writeFileNum == 3 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 5068+maxMetaDataFileSize {
+			// success
+			goto completeReadFileAgain
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic(fmt.Sprintf("%+v", d))
+
+completeReadFileAgain:
+	<-dq.ReadChan()
+	<-dq.ReadChan()
+	<-dq.ReadChan()
+
+	<-dq.ReadChan()
+	<-dq.ReadChan()
+	<-dq.ReadChan()
+	<-dq.ReadChan()
+
+	if dq.Depth() != 0 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		// test that read position and messages reset when a file is completely read
+		// test the readFileNum correctly increments
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 0 &&
+			d.readFileNum == 3 &&
+			d.writeFileNum == 3 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == maxMetaDataFileSize {
+			// success
+			goto done
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+done:
+}
+
+func TestDiskSizeImplementationDiskSizeLimit(t *testing.T) {
+	l := NewTestLogger(t)
+	dqName := "test_disk_queue_implementation_disk_size_limit" + strconv.Itoa(int(time.Now().Unix()))
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	dq := NewWithDiskSpace(dqName, tmpDir, 6040, 1<<11, 0, 1<<10, 2500, 50*time.Millisecond, l)
+	defer dq.Close()
+
+	msgSize := 1000
+	msg := make([]byte, msgSize)
+
+	// meet disk size limit
+	// write a complete file
+	dq.Put(msg)
+	dq.Put(msg)
+	dq.Put(msg)
+
+	// meet the disk size limit exactly (6040 bytes) when writeFileNum
+	// is ahead of readFileNum
+	dq.Put(msg)
+	dq.Put(msg)
+
+	totalDiskBytes := int64(5*(msgSize+4) + 8)
+
+	// save space for msg len and number of msgs in file
+	diskBytesRemaining := 6040 - maxMetaDataFileSize - (totalDiskBytes + 12)
+	dq.Put(make([]byte, diskBytesRemaining))
+
+	depth := dq.Depth()
+	if depth != 6 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		// test that read position and messages reset when a file is completely read
+		// test the readFileNum correctly increments
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 6 &&
+			d.readFileNum == 0 &&
+			d.writeFileNum == 2 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 6040 {
+			// success
+			goto surpassDiskSizeLimit
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+surpassDiskSizeLimit:
+	dq.Put(make([]byte, 1))
+
+	if dq.Depth() != 4 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		// test that read position and messages reset when a file is completely read
+		// test the readFileNum correctly increments
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 4 &&
+			d.readFileNum == 1 &&
+			d.writeFileNum == 2 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 1 &&
+			d.readPos == 0 &&
+			d.writePos == 5 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 3025 {
+			// success
+			goto done
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+done:
+}
+
+func TestDiskSizeImplementationMsgSizeGreaterThanFileSize(t *testing.T) {
+	// write three files
+
+	l := NewTestLogger(t)
+	dqName := "test_disk_queue_implementation_msg_size_greater_than_file_size" + strconv.Itoa(int(time.Now().Unix()))
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	dq := NewWithDiskSpace(dqName, tmpDir, 1<<12, 1<<10, 0, 1<<12, 2500, 50*time.Millisecond, l)
+	defer dq.Close()
+
+	msgSize := 1000
+	msg := make([]byte, msgSize)
+
+	// file size: 1496
+	dq.Put(msg)
+	dq.Put(make([]byte, 480))
+
+	// file size: 1032
+	dq.Put(msg)
+	dq.Put(make([]byte, 16))
+
+	// file size: 1512
+	dq.Put(make([]byte, 1500))
+
+	if dq.Depth() != 5 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 5 &&
+			d.readFileNum == 0 &&
+			d.writeFileNum == 3 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 4040+maxMetaDataFileSize {
+			// success
+			goto writeLargeMsg
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+writeLargeMsg:
+	// Write a large message that causes the deletion of three files
+	dq.Put(make([]byte, 3000))
+
+	if dq.Depth() != 1 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		// test that read position and messages reset when a file is completely read
+		// test the readFileNum correctly increments
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 1 &&
+			d.readFileNum == 3 &&
+			d.writeFileNum == 4 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 3012+maxMetaDataFileSize {
+			// success
+			goto done
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+done:
+}
+
+func createBadFile(dqName string, filePath string, fileNum int64, numBytes int) error {
+	fn := fmt.Sprintf(path.Join(filePath, "%s.diskqueue.%06d.dat.bad"), dqName, fileNum)
+
+	badFile, err := os.OpenFile(fn, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+
+	defer badFile.Close()
+
+	_, err = badFile.Write(make([]byte, numBytes))
+
+	return err
+}
+
+func numberOfBadFiles(diskQueueName string, dataPath string) int64 {
+	var badFilesCount int64
+
+	fileInfos, _ := ioutil.ReadDir(dataPath)
+	for _, fileInfo := range fileInfos {
+		regExp, _ := regexp.Compile(`^` + diskQueueName + `.diskqueue.\d+.dat.bad$`)
+		if regExp.MatchString(fileInfo.Name()) {
+			badFilesCount++
+		}
+	}
+
+	return badFilesCount
+}
+
+func TestDiskSizeImplementationWithBadFiles(t *testing.T) {
+	// write three files
+
+	l := NewTestLogger(t)
+	dqName := "test_disk_queue_implementation_with_bad_files" + strconv.Itoa(int(time.Now().Unix()))
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("nsq-test-%d", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// there should be no .bad files
+	var badFilesCount int64
+	badFilesCount = numberOfBadFiles(dqName, tmpDir)
+	if badFilesCount != 0 {
+		panic("fail")
+	}
+
+	// make 2 bad files
+	createBadFile(dqName, tmpDir, 0, 1503)
+	createBadFile(dqName, tmpDir, 1, 1032)
+
+	badFilesCount = numberOfBadFiles(dqName, tmpDir)
+	if badFilesCount != 2 {
+		panic("fail")
+	}
+
+	dq := NewWithDiskSpace(dqName, tmpDir, 1<<12, 1<<10, 10, 1600, 2500, 50*time.Millisecond, l)
+	defer dq.Close()
+
+	msgSize := 1000
+	msg := make([]byte, msgSize)
+
+	// file 0 size: 1497
+	dq.Put(msg)
+	dq.Put(make([]byte, 481))
+
+	// no bad files should have been deleted
+	badFilesCount = numberOfBadFiles(dqName, tmpDir)
+	if badFilesCount != 2 {
+		panic("fail")
+	}
+
+	// file 1 size: 1032
+	dq.Put(msg)
+	dq.Put(make([]byte, 16))
+
+	// one .bad file should be deleted in order to make space
+	badFilesCount = numberOfBadFiles(dqName, tmpDir)
+	if badFilesCount != 1 {
+		panic("fail")
+	}
+
+	// file 2 size: 1503
+	dq.Put(make([]byte, 1491))
+
+	// check if all the .bad files were deleted
+	badFilesCount = numberOfBadFiles(dqName, tmpDir)
+	if badFilesCount != 0 {
+		panic("fail")
+	}
+
+	depth := dq.Depth()
+	if depth != 5 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.depth == 5 &&
+			d.readFileNum == 0 &&
+			d.writeFileNum == 3 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 4032+maxMetaDataFileSize {
+			// success
+			goto corruptFiles
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+corruptFiles:
+	// test removeReadFile when file is corrupted
+	// create bad files see if totalDiskSpaceUsed is updated properly
+	// check that after corrupting files, we make space appropriately
+
+	// corrupt file 0
+	dqFn := dq.(*diskQueue).fileName(0)
+	os.Truncate(dqFn, 1017) // 1 valid message, 1 corrupted message
+
+	dq.Put(make([]byte, 100))
+
+	// check if the .bad files were deleted
+	badFilesCount = numberOfBadFiles(dqName, tmpDir)
+	if badFilesCount != 0 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.readFileNum == 1 &&
+			d.writeFileNum == 3 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 1 &&
+			d.readPos == 0 &&
+			d.writePos == 104 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 2639+maxMetaDataFileSize {
+			// success
+			goto readCorruptedFile
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("fail")
+
+readCorruptedFile:
+	// test handleReadError
+
+	// there should be no "bad" files at this point
+	badFilesCount = numberOfBadFiles(dqName, tmpDir)
+	if badFilesCount != 0 {
+		panic("fail")
+	}
+
+	// corrupt file 2
+	// have readOne turn it into a bad file and then try to make space
+	dqFn = dq.(*diskQueue).fileName(2)
+	os.Truncate(dqFn, 1020)
+
+	// read file 1
+	<-dq.ReadChan()
+	<-dq.ReadChan()
+
+	// wait for DiskQueue to notice that file 2 is corrupted
+	time.Sleep(1 * time.Second)
+
+	// check if the file was converted into a .bad file
+	badFilesCount = numberOfBadFiles(dqName, tmpDir)
+	if badFilesCount != 1 {
+		panic("fail")
+	}
+
+	// go over the disk limit
+	dq.Put(msg)
+
+	// write a complete file
+	dq.Put(msg)
+	dq.Put(msg)
+
+	// check if the corrupted file was deleted to make space
+	badFilesCount = numberOfBadFiles(dqName, tmpDir)
+	if badFilesCount != 0 {
+		panic("fail")
+	}
+
+	for i := 0; i < 10; i++ {
+		d := readMetaDataFile(dq.(*diskQueue).metaDataFileName(), 0, true)
+		if d.readFileNum == 3 &&
+			d.writeFileNum == 5 &&
+			d.readMessages == 0 &&
+			d.writeMessages == 0 &&
+			d.readPos == 0 &&
+			d.writePos == 0 &&
+			dq.(*diskQueue).totalDiskSpaceUsed == 3132+maxMetaDataFileSize {
 			// success
 			goto done
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/nsqio/go-diskqueue
+module github.com/cloudlinux/go-diskqueue
 
 go 1.13


### PR DESCRIPTION
* Keep track of the number of messages in the writeFile and the number of messages we read in the readFile. Also, reserve the last 4 bytes at the end of the file for the number of messages in that file.

* Update tests to reflect changes made to the metadata file. Metadata file now contains readMessages and writeMessages.

* Test thtat write messages resets when a new file is created.

* Add a test that checks if meta data file is correct after writing a complete file and completely reading a file.

* Allocate 8 bytes instead of 4 since writeMessages is in64, and reset writeMessages and readMessages in skipToNextRWFile.

* Update comment about number of bytes reserved for writeMessages.

* Allow user to choose whether to use new feature or not.

* Separate testing from the original with the implementation of depth for disk space limit.

* Revert to original code style.

* Add comment for functions.

* Explain that maxBytesDiskSpace is 0 when user is not using disk space limit feature.

* Add explicit disk size limit feature flag.

* Add a new line after if block.

* Track the disk space the files tracked by DiskQueue takes up, and test that these numbers are accurate.

* Update totalBytes and writePos when writing number of messages, and resolve the writeMessages off by 1 error.

* Remove the additional 8 bytes to totalBytes.

* Revert "Remove the additional 8 bytes to totalBytes."

This reverts commit 652b548b97ac8c5eb808638fe6bdd80898b3b2b2.

* Revert "Update totalBytes and writePos when writing number of messages, and resolve the writeMessages off by 1 error."

This reverts commit 48c7a85bb1326c9b362a81545e0908af0807ff7a.

* Revert changes that removed the additional 8 bytes.

* Add comment to make code more readable.

* Add test that completes the write file by meeting the file size limit exactly with a message less than 8 bytes.

* Add extra testing to validate the increment/decrement of bytes in core code.

* Update variable names.

* Revert "Update variable names."

This reverts commit e9b23ac5eab849aed8fc2972d06870fcbf243f09.

* Revert "Merge branch 'TrackDiskSize' into DepthImpl"

This reverts commit 76a0ddd1719105e1d13e57988557783b9d6af9bd, reversing changes made to 30c6ef662449c70d289a402bb95cf9759c642e1e.

* Update variable names.

* Replace 8 with a constant to improve readability.

* Reset Diskqueue data during readError.

* Track disk size (#5)

* Remove readBytes and update testing.

* Add comment for readMsgSize.

* Modify disk size limit features only if disk size limit feature is being used .

* Reset write bytes during read error if read file is write file.

* Track writeBytes and readMsgSize.

* Update test.

* Test writeBytes is accurate.

* Make code more readable.

* Revert back to using msgSize instead of readMsgSize in order to make minimal changes.

* Update max bad file size to include numFileMsgsBytes.

* Update go.mod

* Disk size limit (#6)

* Remove readBytes and update testing.

* Add comment for readMsgSize.

* Modify disk size limit features only if disk size limit feature is being used .

* Increase disk size limit in testing, and get MetaData file size.

* Add comments to metaDataFileSize func for better readability.

* Add logic to remove readFile if we are going to surpass the Disk Size Limit.

* Abstract code from moveForward and create makeSpace function to be used when DiskQueue needs to make space.

* Rename func to make it more readable.

* Make space when the new writeMessage will surpass the disk size limit. Test that DiskQueue never surpasses the disk size limit.

* Make space until there is enough space to write the message

* Abstract code and make a reachFileSizeLimit flag.

* Update testing to account for metadata file size.

* Handle the deletion of .bad files if it exists.

* Get oldest bad file info does not need to return an error. It either finds a bad file or does not.

* Track size of bad files.

* Decrease badBytes when we delete a bad file and move badBytes to check if we need to make disk space.

* Remove badBytes from metadata and make it an atomic field.

* Recalculate badBytes if it is a negative number.

* Add comments and rename varaibles to improve readability.

* Update metaData file size now that badBytes is removed from metaData file.

* Prevent user from writing data that is bigger than disk size limit.

* Make the code more readable by changing the order of checks in writeOne().

* Test the scenario when msgSize needs the deletion of several files.

* Use regex when getting diskqueue files with .bad extension.

* Update the tracking of .bad files to use regex.

* Remove log messages.

* Start writing a test to check if .bad files are deleted or accounted for correctly.

* Test that DiskQueue deleted .bad files first in order to make Disk Space.

* Update with to other branches - variable name change and adjust writeBytes, writeMsgs, and readMsgs in handReadError.

* Adjust writeBytes as a result of the initial overestimation of the size of a bad file when we cannot get its accurate size.

* Reset messages in handleReadError

* Use MatchString as opposed to Match.

* Throw error.

* Instead of overestimating bad file size, underestime it. This ensures we will never go over disk limit.

* Add a check to see if readFile is corrupted.

* Remove DEBUG logs.

* test .bad files.

* In progress... corrupt file and then have readOne() deem it corrupted.

* Make code more readable.

* Ensure that diskqueue handles corrupted files correctly.

* Remove badBytes and get the accurate writeBytes data every time a writeFile is deleted or a readFile turns into a bad file.

* Abstract general function to walk through all of the files in the directory DiskQueue writes and reads in.

* Abstract code to its own function.

* Remove readMsgSize and make code more readable.

* Make test code more readable.

* Update go.mod

* Make regexp constants and close metadatafile after getting its size.

* Change writeBytes to totalDiskSpaceUsed and have it track writeBytes and badBytes for now.

* Update panic messages.

* Track the total disk size with one variable rather than several smaller ones.

* Remove unnecessary comments.

* Break up huge function into two smaller functions.

* Ensure that global regExp are created on start.

* Add testing of depth, add info logs, and test when disk size limit is too small (not enough space for meta data file).

* Update name of dq objects to match function name.

* Use ReadDir instead of WalkDir

* Replace go v1.16 functions and objects with <v1.16 functions and objects.

* Have metaData file size stay as 56 bytes and update testing.

* Add the number of bytes that were removed when a file is removed.

* Only get the size if the file was able to be removed successfully.

* Add function to get filder size and update log when removing read file to make space.

* Make the code more readable.

* Extract chunk of code into a new function.

* Improve readability of the code and update code from nsqio/go-diskqueue#29 issue 29

* totalDiskSpaceUsed does not change in handleReadError

* Iterate through each file rather than relying on the totalDiskSpaceUsed variable.

* Revert "Merge branch 'master' into DiskSizeLimit"

This reverts commit 0c456b49e0f550e540caa46599c59e167e4d4158, reversing changes made to a821855461335029764927e2d929c178967a51b6.

* Update README.md

* Update README.md

Updated the Build status, Go reference, and latest Github release

* Read correct number of messages from end of file (#7)

* trivial improvement of some checks

* use file instead of bufio.Reader in readNumOfMessages from file end

Signed-off-by: Leon Ziyang Zhang <leonzz@google.com>

* Update Readme and add description for the fork.

* Update \d\d\d\d\d\d to \d+

* Fixed issue with shared regexps

* Update go.mod

* Fixed conflicting variable issue

* Fixed issue with peekChan

* Reverted switch to next file before maxBytesPerFile is reached

* Fixed issue with .bad files

* Added timeout between corruption checks

* Added more timeout between corruption checks

* Reduced timeouts

* Timeout replaced

* Fixed pattern of bad files

* Ref

* Check failures

* Added error handling

* Fixed tests

Signed-off-by: Leon Ziyang Zhang <leonzz@google.com>
Co-authored-by: Kevin Cam <kevincam@google.com>
Co-authored-by: Kevin Cam <kevinsebcam@gmail.com>
Co-authored-by: CatherineF-dev <78218824+CatherineF-dev@users.noreply.github.com>
Co-authored-by: Leon Ziyang Zhang <leonzz@mikreal.com>
Co-authored-by: Leon Ziyang Zhang <leonzz@google.com>
Co-authored-by: Mikhail Faraponov <mfaraponov@cloudlinux.com>